### PR TITLE
Refactor the looping-queue from ShootingGallery

### DIFF
--- a/Scripts/MyLoopingQueue.cs
+++ b/Scripts/MyLoopingQueue.cs
@@ -1,0 +1,80 @@
+using Godot;
+using System;
+using System.Collections.Generic;  // : List, Dictionary
+using System.Linq;                 // : Enumerable
+
+/// Iterates through a shuffled list of items, which is Reinitialized at a threshold.
+public class MyLoopingQueue
+{
+    private List<string> _template;
+    private List<string> _queue;
+    public int Threshold;
+    public bool Shuffle;
+
+    public MyLoopingQueue(
+        Dictionary<string, int> setup,
+        int threshold = 0,
+        bool shuffle = true
+    ) {
+        Threshold = threshold;
+        Shuffle = shuffle;
+        _template = new List<string>();
+
+        // Adds as many of the string as specified by int
+        foreach (KeyValuePair<string, int> e in setup)
+        {
+            _template.AddRange(Enumerable.Repeat(e.Key, e.Value));
+        }
+
+        Reinitialize();
+    }
+
+    private void Reinitialize()
+    {
+        if (Shuffle)
+        {
+            // Use a temp array to take advantage of built-in shuffle
+            string[] buffer = _template.ToArray();
+            Random.Shared.Shuffle(buffer);
+            _queue = new List<string>(buffer);
+        }
+        else
+        {
+            _queue = new List<string>(_template);
+        }
+    }
+
+    /// Retrieve and remove one item; shuffle if beneath threshold
+    public string Pop()
+    {
+        string item;
+        // Reload queue and shuffle if under threshold
+        if (_queue.Count <= Threshold)
+        {
+            Reinitialize();
+        }
+        // Pop the item
+        item = _queue[0];
+        _queue.RemoveAt(0);
+        return item;
+    }
+
+    /// Get a string representation of the queue as is
+    public string Repr()
+    {
+        if (_queue != null)
+        {
+            string str = "MyLoopingQueue: {\n";
+            foreach (var e in _queue)
+            {
+                str += $"    {e}\n";
+            }
+            return str + "}\n";
+        }
+        else
+        {
+            return "null";
+        }
+
+    }
+}

--- a/Scripts/MyLoopingQueue.cs.uid
+++ b/Scripts/MyLoopingQueue.cs.uid
@@ -1,0 +1,1 @@
+uid://bh2juuln182hx

--- a/Scripts/ShootingGallery.cs
+++ b/Scripts/ShootingGallery.cs
@@ -1,6 +1,6 @@
 using Godot;
 using System;
-using System.Collections.Generic;  // For List
+using System.Collections.Generic;  // For List and Dictionary
 using System.Linq;  // for [].Count
 
 
@@ -25,22 +25,17 @@ public partial class ShootingGallery : Node3D
         "Spawns/Path1/Stretch",
     };
 
-    // A queue (shuffled elsewhere) which determines rate of balls spawning
-    private string[] _ballQueueTemplate = new string[]
-    {
-        "res://Scenes/balloon.tscn",
-        "res://Scenes/balloon.tscn",
-        "res://Scenes/watermelon.tscn",
-        "res://Scenes/small_ball.tscn",
-        "res://Scenes/small_ball.tscn",
-        "res://Scenes/small_ball.tscn",
-        "res://Scenes/small_ball.tscn",
-        "res://Scenes/small_ball.tscn",
-        "res://Scenes/small_ball.tscn",
-        "res://Scenes/small_ball.tscn",
-    };
+    // A queue which determines randomized spawnrates
+    private MyLoopingQueue _spawnQueue = new MyLoopingQueue(
+        setup: new Dictionary<string,int>
+        {
+            { "res://Scenes/balloon.tscn",    2 },
+            { "res://Scenes/watermelon.tscn", 2 },
+            { "res://Scenes/small_ball.tscn", 16 }
+        },
+        threshold: 2
+    );
 
-    private List<string> _ballQueue = new List<string>();
     private AudioStreamPlayer _audioPlayer;
 
     private Health _health;
@@ -84,35 +79,6 @@ public partial class ShootingGallery : Node3D
 
     }
 
-    /// Loads balls in from a randomized queue
-    private PackedScene LoadRandomBall()
-    {
-        PackedScene ballScene;
-
-        // When queue is empty
-        if (_ballQueue.Count == 0)
-        {
-            // Reload queue with a shuffled template
-            Random.Shared.Shuffle(_ballQueueTemplate);
-            _ballQueue = new List<string>(_ballQueueTemplate);
-
-            // Load and return one with uniform randomness
-            // For a bit o' spice
-            ballScene = GD.Load<PackedScene>(
-                PATH_BALLS[GD.Randi() % PATH_BALLS.Length]
-            );
-            return ballScene;
-        }
-        else
-        {
-            // Load one item and remove it from the queue
-            ballScene = GD.Load<PackedScene>(_ballQueue[0]);
-            _ballQueue.RemoveAt(0);
-        }
-
-        return ballScene;
-    }
-
     private Vector3 GetSpawnPosition()
     {
         var path = GetNode<PathFollow3D>(PATH_LOCATIONS[0]);
@@ -145,7 +111,9 @@ public partial class ShootingGallery : Node3D
     /// Spawn a ball at a random location
     private void OnBallTimerTimeout()
     {
-        var ball = LoadRandomBall().Instantiate();
+        // Load a ball from the randomized queue
+        PackedScene ballScene = GD.Load<PackedScene>(_spawnQueue.Pop());
+        var ball = ballScene.Instantiate();
         Vector3 spawn = GetSpawnPosition();
         // target here is a bit over the middle of the backboard
         var target = new Vector3(0, 7.0f, 0);


### PR DESCRIPTION
Simplifies quite a bit in ShootingGallery. You'll notice how this simplifies the interface to initializing the spawn queue for balls, and removes the need for some variables and a pretty ugly method.

Though, it was mostly unnecessary. I just wanted to go on a short refactoring-adventure. There's really more important things to do right now.

commit 07a7f08f48779afd88d9d13d102fff919fee7a4b
Author: Wilhelmsen <wwilhelmsen@sogn.no>
Date:   Thu Oct 16 00:27:46 2025 +0200

    Utilize the new LoopingQueue in ShootingGallery

commit 2a0fd1d41257b5477d31be28dd2e1146e7f010c2
Author: Wilhelmsen <wwilhelmsen@sogn.no>
Date:   Thu Oct 16 00:14:02 2025 +0200

    Implement looping queue class

commit d698c94c29f574ff233081e2f48bb2e7e87714ea
Author: Wilhelmsen <wwilhelmsen@sogn.no>
Date:   Wed Oct 15 23:51:52 2025 +0200

    Start classification of looping queue functionality